### PR TITLE
Fix debounce performance issues

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,10 +2,14 @@ import inherited from './inherited'
 import nonInherited from './nonInherited'
 
 const debounce = (fn) => {
-  let timeoutId
+  let pending = false
   return (...args) => {
-    clearTimeout(timeoutId)
-    timeoutId = setTimeout(() => fn(...args))
+    if (pending) return
+    pending = true
+    setTimeout(() => {
+      fn(...args)
+      pending = false
+    })
   }
 }
 


### PR DESCRIPTION
We discovered that the current `debounce` function screws up the timeline recording in Chrome.
This patch fixes the issue and also improves overall performance.